### PR TITLE
Fix crash with GDDP Integration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,18 @@ class $modify(BetterCreatorLayer, CreatorLayer) {
 
                     auto originalGddpNode = creatorButtonsMenu->getChildByID("demon-progression-button");
                     auto originalGddpButton = static_cast<CCMenuItemSpriteExtra*>(originalGddpNode);
+                    CCNode* centerRightMenu = getChildByID("minemaker0430.gddp_integration/center-right-menu");
+                    if (!centerRightMenu) centerRightMenu = getChildByID("cvolton.betterinfo/center-right-menu");
+                    if (!originalGddpButton && centerRightMenu) {
+                      originalGddpButton = static_cast<CCMenuItemSpriteExtra*>(centerRightMenu->getChildByID("demon-progression-button"));
+                    }
+
                     originalGddpButton->setVisible(false);
+                    if (centerRightMenu) {
+                      geode::Layout* layout = centerRightMenu->getLayout();
+                      if (layout) layout->ignoreInvisibleChildren(true);
+                      centerRightMenu->updateLayout();
+                    }
 
                     auto gddpButtonColor = Mod::get()->getSettingValue<std::string>("gddp-color-setting");
                     CircleBaseColor gddpButtonColorV = getColor(gddpButtonColor);
@@ -281,8 +292,18 @@ class $modify(BetterCreatorLayer, CreatorLayer) {
                 Mod::get()->setSavedValue("gddp-enabled", true);
                 auto originalGddpNode = creatorButtonsMenu->getChildByID("demon-progression-button");
                 auto originalGddpButton = static_cast<CCMenuItemSpriteExtra*>(originalGddpNode);
+                CCNode* centerRightMenu = getChildByID("minemaker0430.gddp_integration/center-right-menu");
+                if (!centerRightMenu) centerRightMenu = getChildByID("cvolton.betterinfo/center-right-menu");
+                if (!originalGddpButton && centerRightMenu) {
+                  originalGddpButton = static_cast<CCMenuItemSpriteExtra*>(centerRightMenu->getChildByID("demon-progression-button"));
+                }
 
                 originalGddpButton->setVisible(false);
+                if (centerRightMenu) {
+                  geode::Layout* layout = centerRightMenu->getLayout();
+                  if (layout) layout->ignoreInvisibleChildren(true);
+                  centerRightMenu->updateLayout();
+                }
 
                 auto gddpButtonColor = Mod::get()->getSettingValue<std::string>("gddp-color-setting");
                 CircleBaseColor gddpButtonColorV = getColor(gddpButtonColor);


### PR DESCRIPTION
If compact icon is on, GDDP creates a center right menu `minemaker0430.gddp_integration/center-right-menu`, if a center right menu `cvolton.betterinfo/center-right-menu` does not already exist, and then puts the compact button into that menu; take the button from there if the search for the original fails.

This slightly mishandles the "Replace Map Packs" option in GDDP Integration; it doesn't crash or anything, it's just that this mod still shows the map packs button if the option in GDDP Integration is on, which isn't really a problem.

You could fix that by checking for the option and not adding the map packs button into the bottom/left menus if it's on.